### PR TITLE
Match Content-Length / Transfer-Encoding case-insensitively (RFC 9110)

### DIFF
--- a/src/drop.c
+++ b/src/drop.c
@@ -1,5 +1,6 @@
 // Copyright 2016 by Peter Ohler, All Rights Reserved
 
+#define _GNU_SOURCE
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>
@@ -150,7 +151,7 @@ drop_recv(Drop d) {
 	    if (0 < p->xsize && 0 == memcmp(p->xbuf, d->buf, p->xsize)) {
 		d->xsize = p->xsize;
 	    } else {
-		char	*cl = strstr(d->buf, content_length);
+		char	*cl = strcasestr(d->buf, content_length);
 		char	*hend;
 
 		if (NULL == cl) {
@@ -162,7 +163,7 @@ drop_recv(Drop d) {
 		    return 0;
 		}
 		if (NULL == cl) {
-		    char	*te = strstr(d->buf, transfer_encoding);
+		    char	*te = strcasestr(d->buf, transfer_encoding);
 
 		    // TBD Handle chunking correctly. This approach only works
 		    // when all the chunks come in one read and no more than that.
@@ -273,7 +274,7 @@ drop_warmup_recv(Drop d) {
 	d->rcnt += rcnt;
 	if (0 < d->rcnt) {
 	    if (0 >= d->xsize) {
-		char	*cl = strstr(d->buf, content_length);
+		char	*cl = strcasestr(d->buf, content_length);
 		char	*hend;
 
 		if (NULL == cl) {
@@ -285,7 +286,7 @@ drop_warmup_recv(Drop d) {
 		    return 0;
 		}
 		if (NULL == cl) {
-		    char	*te = strstr(d->buf, transfer_encoding);
+		    char	*te = strcasestr(d->buf, transfer_encoding);
 
 		    // TBD Handle chunking correctly. This approach only works
 		    // when all the chunks come in one read and no more than that.


### PR DESCRIPTION
## Summary

`drop.c` parses response headers using `strstr()` to find `Content-Length:` and `Transfer-Encoding:`. RFC 9110 §5.1 says HTTP field names are case-insensitive, and most modern HTTP servers (Falcon, Iodine, Hyperion, anything on rack 3+) emit the canonical lowercase form (`content-length:`). `strstr()` is case-sensitive, so perfer never finds the header, sits waiting for more bytes, and eventually times out — reporting 0 r/s against any server that doesn't capitalize its response headers.

This switches the four call sites in `drop.c` to `strcasestr()` and defines `_GNU_SOURCE` at the top of the file so the glibc declaration is exposed.

## Test plan

- [x] Build cleanly on Ubuntu 24.04 / glibc (`make`).
- [x] Verified against [Hyperion](https://github.com/andrew-woblavobla/hyperion) 2.10.x (lowercase headers): pre-patch perfer reports 0 r/s on every variant; post-patch perfer reports the actual server throughput, matching `wrk` numbers within ~3% on the same workloads.
- [x] Verified against Agoo 2.15.14 (capitalized headers): unchanged — the casing match still finds the header on the original input shape, since `strcasestr()` matches case-insensitively in both directions.
- [ ] BSD / macOS portability: `strcasestr()` is available on both without `_GNU_SOURCE`. The `#define` is a no-op outside glibc — wrapping it in `#ifdef __linux__` would be safer, happy to make that change if preferred.

## Notes

This is a tiny correctness fix; happy to break it into per-call-site commits or wrap `_GNU_SOURCE` in a feature-test macro guard if either fits the project's style better. The four touched lines are at `drop.c:153`, `:165`, `:276`, and `:288`.

[Reference: RFC 9110 §5.1 — "Field names are case-insensitive..."](https://www.rfc-editor.org/rfc/rfc9110#section-5.1)